### PR TITLE
fix: prevent cut off bottom of h1

### DIFF
--- a/src/WebContainer/files/styles/slidevookDefault.css
+++ b/src/WebContainer/files/styles/slidevookDefault.css
@@ -8,6 +8,7 @@
   -webkit-text-fill-color: transparent;
   -moz-text-fill-color: transparent;
   width: fit-content;
+  line-height: 2.75rem;
 }
 
 .slidev-layout h2 {


### PR DESCRIPTION
prevent cut off bottom of h1

before

![image](https://user-images.githubusercontent.com/7125192/226893941-1a22611b-84c1-4176-8c54-798b88d0cada.png)

after

![image](https://user-images.githubusercontent.com/7125192/226894071-b4137521-6904-4b08-8a89-f568c05813bb.png)
